### PR TITLE
FEATURE: Support workspaces, UI improvements and canceling specific releases

### DIFF
--- a/Classes/Command/ContentReleasePrepareCommandController.php
+++ b/Classes/Command/ContentReleasePrepareCommandController.php
@@ -28,23 +28,23 @@ class ContentReleasePrepareCommandController extends CommandController
      */
     protected $concurrentBuildLock;
 
-    public function createContentReleaseCommand(string $contentReleaseIdentifier, string $prunnerJobId)
+    public function createContentReleaseCommand(string $contentReleaseIdentifier, string $prunnerJobId, string $workspaceName = 'live'): void
     {
         $contentReleaseIdentifier = ContentReleaseIdentifier::fromString($contentReleaseIdentifier);
         $prunnerJobId = PrunnerJobId::fromString($prunnerJobId);
         $logger = ContentReleaseLogger::fromConsoleOutput($this->output, $contentReleaseIdentifier);
 
-        $this->redisContentReleaseService->createContentRelease($contentReleaseIdentifier, $prunnerJobId, $logger);
+        $this->redisContentReleaseService->createContentRelease($contentReleaseIdentifier, $prunnerJobId, $logger, $workspaceName);
     }
 
-    public function ensureAllOtherInProgressContentReleasesWillBeTerminatedCommand(string $contentReleaseIdentifier)
+    public function ensureAllOtherInProgressContentReleasesWillBeTerminatedCommand(string $contentReleaseIdentifier): void
     {
         $contentReleaseIdentifier = ContentReleaseIdentifier::fromString($contentReleaseIdentifier);
 
         $this->concurrentBuildLock->ensureAllOtherInProgressContentReleasesWillBeTerminated($contentReleaseIdentifier);
     }
 
-    public function registerManualTransferJobCommand(string $contentReleaseIdentifier, string $prunnerJobId)
+    public function registerManualTransferJobCommand(string $contentReleaseIdentifier, string $prunnerJobId): void
     {
         $contentReleaseIdentifier = ContentReleaseIdentifier::fromString($contentReleaseIdentifier);
         $prunnerJobId = PrunnerJobId::fromString($prunnerJobId);

--- a/Classes/ContentReleaseManager.php
+++ b/Classes/ContentReleaseManager.php
@@ -56,12 +56,12 @@ class ContentReleaseManager
         $contentReleaseId = ContentReleaseIdentifier::create();
         // the currentContentReleaseId is not used in any pipeline step in this package, but is a common need in other
         // use cases in extensions, e.g. calculating the differences between current and new release
-        $this->prunnerApiService->schedulePipeline(PipelineName::create('do_content_release'), array_merge([
+        $this->prunnerApiService->schedulePipeline(PipelineName::create('do_content_release'), array_merge($additionalVariables, [
             'contentReleaseId' => $contentReleaseId,
             'currentContentReleaseId' => $currentContentReleaseId ?: self::NO_PREVIOUS_RELEASE,
             'validate' => true,
             'workspaceName' => $workspace ? $workspace->getName() : 'live',
-        ], $additionalVariables));
+        ]));
         return $contentReleaseId;
     }
 
@@ -75,12 +75,12 @@ class ContentReleaseManager
 
         $contentReleaseId = ContentReleaseIdentifier::create();
         $this->contentCache->flush();
-        $this->prunnerApiService->schedulePipeline(PipelineName::create('do_content_release'), array_merge([
+        $this->prunnerApiService->schedulePipeline(PipelineName::create('do_content_release'), array_merge($additionalVariables, [
             'contentReleaseId' => $contentReleaseId,
             'currentContentReleaseId' => $currentContentReleaseId ?: self::NO_PREVIOUS_RELEASE,
             'validate' => $validate,
             'workspaceName' => $workspace ? $workspace->getName() : 'live',
-        ], $additionalVariables));
+        ]));
         return $contentReleaseId;
     }
 

--- a/Classes/ContentReleaseManager.php
+++ b/Classes/ContentReleaseManager.php
@@ -7,6 +7,7 @@ namespace Flowpack\DecoupledContentStore;
 use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\ContentReleaseIdentifier;
 use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\RedisInstanceIdentifier;
 use Flowpack\DecoupledContentStore\Core\Infrastructure\RedisClientManager;
+use Flowpack\Prunner\ValueObject\JobId;
 use Neos\Flow\Annotations as Flow;
 use Flowpack\Prunner\PrunnerApiService;
 use Flowpack\Prunner\ValueObject\PipelineName;
@@ -78,6 +79,18 @@ class ContentReleaseManager
         $runningJobs = $result->getJobs()->forPipeline(PipelineName::create('do_content_release'))->running();
         foreach ($runningJobs as $job) {
             $this->prunnerApiService->cancelJob($job);
+        }
+    }
+
+    public function cancelRunningContentReleases(JobId $jobId): void
+    {
+        $result = $this->prunnerApiService->loadPipelinesAndJobs();
+        $runningJobs = $result->getJobs()->forPipeline(PipelineName::create('do_content_release'))->running();
+        foreach ($runningJobs as $job) {
+            if ($job->getId() !== $jobId) {
+                $this->prunnerApiService->cancelJob($job);
+                break;
+            }
         }
     }
 

--- a/Classes/ContentReleaseManager.php
+++ b/Classes/ContentReleaseManager.php
@@ -84,7 +84,7 @@ class ContentReleaseManager
         return $contentReleaseId;
     }
 
-    public function cancelAllRunningContentReleases()
+    public function cancelAllRunningContentReleases(): void
     {
         $result = $this->prunnerApiService->loadPipelinesAndJobs();
         $runningJobs = $result->getJobs()->forPipeline(PipelineName::create('do_content_release'))->running();
@@ -93,19 +93,22 @@ class ContentReleaseManager
         }
     }
 
-    public function cancelRunningContentReleases(JobId $jobId): void
+    /**
+     * Cancel a single running content release ignoring all others
+     */
+    public function cancelRunningContentRelease(JobId $jobId): void
     {
         $result = $this->prunnerApiService->loadPipelinesAndJobs();
         $runningJobs = $result->getJobs()->forPipeline(PipelineName::create('do_content_release'))->running();
         foreach ($runningJobs as $job) {
-            if ($job->getId() !== $jobId) {
+            if ($job->getId() === $jobId) {
                 $this->prunnerApiService->cancelJob($job);
                 break;
             }
         }
     }
 
-    public function toggleConfigEpoch(RedisInstanceIdentifier $redisInstanceIdentifier)
+    public function toggleConfigEpoch(RedisInstanceIdentifier $redisInstanceIdentifier): void
     {
         $currentConfigEpochConfig = $this->configEpochSettings['current'] ?? null;
         $previousConfigEpochConfig = $this->configEpochSettings['previous'] ?? null;

--- a/Classes/Core/Domain/ValueObject/ContentReleaseIdentifier.php
+++ b/Classes/Core/Domain/ValueObject/ContentReleaseIdentifier.php
@@ -11,10 +11,7 @@ use Neos\Flow\Annotations as Flow;
 final class ContentReleaseIdentifier implements \JsonSerializable
 {
 
-    /**
-     * @var string
-     */
-    private $identifier;
+    private string $identifier;
 
     private function __construct(string $identifier)
     {
@@ -39,9 +36,6 @@ final class ContentReleaseIdentifier implements \JsonSerializable
         return $this->identifier;
     }
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string
     {
         return $this->identifier;
@@ -50,5 +44,10 @@ final class ContentReleaseIdentifier implements \JsonSerializable
     public function equals(?ContentReleaseIdentifier $other): bool
     {
         return $other !== null && $this->identifier === $other->identifier;
+    }
+
+    public function __toString(): string
+    {
+        return $this->identifier;
     }
 }

--- a/Classes/NodeRendering/Extensibility/NodeRenderingExtensionManager.php
+++ b/Classes/NodeRendering/Extensibility/NodeRenderingExtensionManager.php
@@ -79,18 +79,21 @@ class NodeRenderingExtensionManager
         }
     }
 
-    static private function instantiateExtensions(array $configuration, string $extensionInterfaceName): array
+    private static function instantiateExtensions(array $configuration, string $extensionInterfaceName): array
     {
-        $instanciatedExtensions = [];
+        $instantiatedExtensions = [];
         foreach ($configuration as $extensionConfig) {
+            if (!is_array($extensionConfig)) {
+                continue;
+            }
             $className = $extensionConfig['className'];
             $instance = new $className();
             if (!($instance instanceof $extensionInterfaceName)) {
                 throw new \RuntimeException('Extension ' . get_class($instance) . ' does not implement ' . $extensionInterfaceName);
             }
-            $instanciatedExtensions[] = $instance;
+            $instantiatedExtensions[] = $instance;
 
         }
-        return $instanciatedExtensions;
+        return $instantiatedExtensions;
     }
 }

--- a/Resources/Private/BackendFusion/Integration/Backend.Index.fusion
+++ b/Resources/Private/BackendFusion/Integration/Backend.Index.fusion
@@ -107,24 +107,25 @@ Flowpack.DecoupledContentStore.BackendController.index = Neos.Fusion:Component {
                         </tbody>
                     </table>
 
-                    <span>Store size: </span>
-                    <span class="neos-badge neos-badge-info">{storeSize}</span>
-                    <br />
-                    <button form="postHelper" formaction={props._publishAllWithoutValidationUri} type="submit" class="neos-button neos-button-danger" style="margin-top: 300px;">
-                        Publish all without validation
-                    </button>
-                    <span> </span>
-                    <button form="postHelper" formaction={props._pruneContentStoreUri} type="submit" class="neos-button neos-button-warning" style="margin-top: 300px;">
-                        Prune content store
-                    </button>
-                    <span> </span>
-                    <button form="postHelper" formaction={props._cancelRunningReleaseUri} type="submit" class="neos-button neos-button-warning" style="margin-top: 300px;">
-                        Cancel running release
-                    </button>
-                    <span> </span>
-                    <button @if.showToggleConfigEpochButton={showToggleConfigEpochButton} form="postHelper" formaction={props._toggleConfigEpoch} type="submit" class="neos-button neos-button-danger" style="margin-top: 300px;">
-                        {'Toggle config epoch: ' + toggleFromConfigEpoch + ' to ' + toggleToConfigEpoch}
-                    </button>
+                    <div>
+                        <span>Store size: </span>
+                        <span class="neos-badge neos-badge-info">{storeSize}</span>
+                    </div>
+
+                    <div style="margin-top: 5rem; display: flex; gap: 1rem;">
+                      <button form="postHelper" formaction={props._publishAllWithoutValidationUri} type="submit" class="neos-button neos-button-danger">
+                          Publish all without validation
+                      </button>
+                      <button form="postHelper" formaction={props._pruneContentStoreUri} type="submit" class="neos-button neos-button-warning">
+                          Prune content store
+                      </button>
+                      <button form="postHelper" formaction={props._cancelRunningReleaseUri} type="submit" class="neos-button neos-button-warning">
+                          Cancel running release
+                      </button>
+                      <button @if.showToggleConfigEpochButton={showToggleConfigEpochButton} form="postHelper" formaction={props._toggleConfigEpoch} type="submit" class="neos-button neos-button-danger" style="margin-top: 300px;">
+                          {'Toggle config epoch: ' + toggleFromConfigEpoch + ' to ' + toggleToConfigEpoch}
+                      </button>
+                    </div>
 
                     <div class="neos-footer !h-full">
                         <Flowpack.DecoupledContentStore:ListFooter />

--- a/Resources/Private/BackendFusion/Integration/Backend.Index.fusion
+++ b/Resources/Private/BackendFusion/Integration/Backend.Index.fusion
@@ -141,13 +141,19 @@ prototype(Flowpack.DecoupledContentStore:ListFooter) < prototype(Neos.Fusion:Joi
             <i class="fa fa-sync"></i> Reload
         </Neos.Fusion:Link.Action>
     `
-    activeContentStoreLabel = '<span class="align-middle inline-block text-sm pr-4 pl-16">Active Content Store:</span>'
     switchContentStore = afx`
-        <Neos.Fusion:Loop items={redisContentStores}>
-            <Neos.Fusion:Link.Action href.action="index" href.arguments={{contentStore: item}} class={AtomicFusion.classNames('neos-button', {'neos-button-primary': item == contentStore})}>
-                {item}
-            </Neos.Fusion:Link.Action>
-        </Neos.Fusion:Loop>
+        <span class="align-middle inline-block text-sm pr-4 pl-16">
+            Active Content Store: &nbsp;
+            <Neos.Fusion:Loop items={redisContentStores}>
+                <Neos.Fusion:Link.Action
+                    href.action="index"
+                    href.arguments={{contentStore: item}}
+                    class={['neos-button', 'text-sm', item == contentStore && 'neos-button-primary']}
+                >
+                    {item}
+                </Neos.Fusion:Link.Action>
+            </Neos.Fusion:Loop>
+        </span>
     `
     publishAll = Neos.Fusion:Component {
         _publishAllUri = Neos.Fusion:UriBuilder {

--- a/pipelines_template.yml
+++ b/pipelines_template.yml
@@ -34,7 +34,7 @@ pipelines:
       ################################################################################
       prepare_finished:
         script:
-          - ./flow contentReleasePrepare:createContentRelease {{ .contentReleaseId }} {{ .__jobID }}
+          - ./flow contentReleasePrepare:createContentRelease {{ .contentReleaseId }} {{ .__jobID }} {{ .workspaceName }}
           - ./flow contentReleasePrepare:ensureAllOtherInProgressContentReleasesWillBeTerminated {{ .contentReleaseId }}
 
       ################################################################################


### PR DESCRIPTION
This PR contains a list of enhancements created during the integration of the package into the 1&1 project.

* Return ContentRelease identifier when started
* Cancel content release by id
* Define workspace which should be released
* Additional custom variables when starting a release
* Allow disabling specific node rendering extensions
* Fix content store list and buttons in the backend module