### PR TITLE
BUGFIX: Fix access to uninitialized security context during full publish

### DIFF
--- a/Classes/ContentReleaseManager.php
+++ b/Classes/ContentReleaseManager.php
@@ -68,7 +68,9 @@ class ContentReleaseManager
             'currentContentReleaseId' => $currentContentReleaseId ?: self::NO_PREVIOUS_RELEASE,
             'validate' => true,
             'workspaceName' => $workspace ? $workspace->getName() : 'live',
-            'accountId' => $this->securityContext->getAccount()->getAccountIdentifier(),
+            'accountId' => $this->securityContext->isInitialized()
+                ? $this->securityContext->getAccount()->getAccountIdentifier() :
+                null,
         ]));
         return $contentReleaseId;
     }
@@ -88,7 +90,9 @@ class ContentReleaseManager
             'currentContentReleaseId' => $currentContentReleaseId ?: self::NO_PREVIOUS_RELEASE,
             'validate' => $validate,
             'workspaceName' => $workspace ? $workspace->getName() : 'live',
-            'accountId' => $this->securityContext->getAccount()->getAccountIdentifier(),
+            'accountId' => $this->securityContext->isInitialized()
+                ? $this->securityContext->getAccount()->getAccountIdentifier() :
+                null,
         ]));
         return $contentReleaseId;
     }


### PR DESCRIPTION
A full publish seems to be triggered more than once and when it is triggered via cli, there is no security context.