### PR TITLE
BUGFIX: Add html escaping to stderr and stdout of job logs

### DIFF
--- a/Resources/Private/BackendFusion/Integration/Backend.Details.fusion
+++ b/Resources/Private/BackendFusion/Integration/Backend.Details.fusion
@@ -40,10 +40,10 @@ Flowpack.DecoupledContentStore.BackendController.details = Neos.Fusion:Component
 
               <h2 @if.isTrue={detailTaskName} class="text-3xl py-5">Log Output for {detailTaskName}</h2>
               <pre>
-                  {jobLogs.stderr}
+                  {String.htmlSpecialChars(jobLogs.stderr)}
               </pre>
               <pre>
-                  {jobLogs.stdout}
+                  {String.htmlSpecialChars(jobLogs.stdout)}
               </pre>
             </Neos.Fusion:Fragment>
             <p @if.notData={!detailsData}>


### PR DESCRIPTION
Log output for a job of a Content Release might contain html in error messages which should be escaped to be readable 