### PR TITLE
BUGFIX: Prevent division by zero in sparkline rendering

### DIFF
--- a/Classes/Utility/Sparkline.php
+++ b/Classes/Utility/Sparkline.php
@@ -13,6 +13,11 @@ class Sparkline
      */
     private static function getY($max, $height, $diff, $value)
     {
+        // prevent division by zero
+        if ($max === 0) {
+            return round(floatval(($height + $diff)), 2);
+        }
+
         return round(floatval(($height - ($value * $height / $max) + $diff)), 2);
     }
 


### PR DESCRIPTION
This happens in odd cases. I think crashing the whole ContentRelease because of a sparkline error doesn't help.

If `max === 0` we just render a 0 value.