### PR TITLE
TASK: Add Fusion object for ContentStore actions

### DIFF
--- a/Resources/Private/BackendFusion/Integration/Backend.Index.fusion
+++ b/Resources/Private/BackendFusion/Integration/Backend.Index.fusion
@@ -10,31 +10,6 @@ Flowpack.DecoupledContentStore.BackendController.index = Neos.Fusion:Component {
     // - showToggleConfigEpochButton: boolean
 
     renderer = Neos.Fusion:Component {
-        _publishAllWithoutValidationUri = Neos.Fusion:UriBuilder {
-            action = 'publishAllWithoutValidation'
-        }
-
-        _pruneContentStoreUri = Neos.Fusion:UriBuilder {
-            action = 'pruneContentStore'
-            arguments = Neos.Fusion:DataStructure {
-                redisInstanceIdentifier = ${contentStore}
-            }
-        }
-
-        _cancelRunningReleaseUri = Neos.Fusion:UriBuilder {
-            action = 'cancelRunningRelease'
-            arguments = Neos.Fusion:DataStructure {
-                redisInstanceIdentifier = ${contentStore}
-            }
-        }
-
-        _toggleConfigEpoch = Neos.Fusion:UriBuilder {
-            action = 'toggleConfigEpoch'
-            arguments = Neos.Fusion:DataStructure {
-                redisInstanceIdentifier = ${contentStore}
-            }
-        }
-
         _renderedTableBody = Neos.Fusion:Loop {
             items = ${overviewData}
             itemRenderer = Neos.Fusion:Component {
@@ -114,26 +89,78 @@ Flowpack.DecoupledContentStore.BackendController.index = Neos.Fusion:Component {
                         <span class="neos-badge neos-badge-info">{storeSize}</span>
                     </div>
 
-                    <div style="margin-top: 5rem; display: flex; gap: 1rem;">
-                      <button form="postHelper" formaction={props._publishAllWithoutValidationUri} type="submit" class="neos-button neos-button-danger">
-                          Publish all without validation
-                      </button>
-                      <button form="postHelper" formaction={props._pruneContentStoreUri} type="submit" class="neos-button neos-button-warning">
-                          Prune content store
-                      </button>
-                      <button form="postHelper" formaction={props._cancelRunningReleaseUri} type="submit" class="neos-button neos-button-warning">
-                          Cancel running release
-                      </button>
-                      <button @if.showToggleConfigEpochButton={showToggleConfigEpochButton} form="postHelper" formaction={props._toggleConfigEpoch} type="submit" class="neos-button neos-button-danger" style="margin-top: 300px;">
-                          {'Toggle config epoch: ' + toggleFromConfigEpoch + ' to ' + toggleToConfigEpoch}
-                      </button>
-                    </div>
+                    <Flowpack.DecoupledContentStore:ContentStoreActions />
 
                     <div class="neos-footer !h-full">
                         <Flowpack.DecoupledContentStore:ListFooter />
                     </div>
                 </div>
             </div>
+        `
+    }
+}
+
+prototype(Flowpack.DecoupledContentStore:ContentStoreActions) < prototype(Neos.Fusion:Join) {
+    @process.wrap = afx`
+        <div style="margin-top: 5rem; display: flex; gap: 1rem;">
+            {value}
+        </div>
+    `
+
+    publishAllWithoutValidation = Neos.Fusion:Component {
+        _publishAllWithoutValidationUri = Neos.Fusion:UriBuilder {
+            action = 'publishAllWithoutValidation'
+        }
+
+        renderer = afx`
+            <button form="postHelper" formaction={props._publishAllWithoutValidationUri} type="submit" class="neos-button neos-button-danger">
+                Publish all without validation
+            </button>
+        `
+    }
+
+    pruneContentStore = Neos.Fusion:Component {
+        _pruneContentStoreUri = Neos.Fusion:UriBuilder {
+            action = 'pruneContentStore'
+            arguments = Neos.Fusion:DataStructure {
+                redisInstanceIdentifier = ${contentStore}
+            }
+        }
+
+        renderer = afx`
+            <button form="postHelper" formaction={props._pruneContentStoreUri} type="submit" class="neos-button neos-button-warning">
+                Prune content store
+            </button>
+        `
+    }
+
+    cancelRunningRelease = Neos.Fusion:Component {
+        _cancelRunningReleaseUri = Neos.Fusion:UriBuilder {
+            action = 'cancelRunningRelease'
+            arguments = Neos.Fusion:DataStructure {
+                redisInstanceIdentifier = ${contentStore}
+            }
+        }
+
+        renderer = afx`
+            <button form="postHelper" formaction={props._cancelRunningReleaseUri} type="submit" class="neos-button neos-button-warning">
+                Cancel running release
+            </button>
+        `
+    }
+
+    toggleConfigEpoch = Neos.Fusion:Component {
+        _toggleConfigEpochUri = Neos.Fusion:UriBuilder {
+            action = 'toggleConfigEpoch'
+            arguments = Neos.Fusion:DataStructure {
+                redisInstanceIdentifier = ${contentStore}
+            }
+        }
+
+        renderer = afx`
+            <button @if.showToggleConfigEpochButton={showToggleConfigEpochButton} form="postHelper" formaction={props._toggleConfigEpochUri} type="submit" class="neos-button neos-button-danger" style="margin-top: 300px;">
+                {'Toggle config epoch: ' + toggleFromConfigEpoch + ' to ' + toggleToConfigEpoch}
+            </button>
         `
     }
 }


### PR DESCRIPTION
We need more fine-grained control over which ContentStore actions are available for users.

I originally planned to create a more sophisticated privilege setup but I opted for the more simple, extensible, non-breaking option.

By adding a Fusion object for the ContentStore actions (I just chose this naming) the consuming application can override it separately from the rest of the Fusion code.

I used the code style of the existing Fusion code to keep it somewhat consistent.

Example:
```
prototype(Flowpack.DecoupledContentStore:ContentStoreActions) {
    # example override
    @if.userIsPrivileged = ${Security.hasRole('Neos.Neos:Administrator')}
}
```

### IMPORTANT
The only breaking change I can see right now is the change of the location of `Flowpack.DecoupledContentStore.BackendController.index._publishAllWithoutValidationUri` etc.
It is now available at `Flowpack.DecoupledContentStore:ContentStoreActions.publishAllWithoutValidation._publishAllWithoutValidationUri`.