### PR TITLE
FEATURE: add show all errors log to aggregate errors from all workers

### DIFF
--- a/Classes/BackendUi/Dto/WorkerErrorLog.php
+++ b/Classes/BackendUi/Dto/WorkerErrorLog.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\DecoupledContentStore\BackendUi\Dto;
+
+use Flowpack\DecoupledContentStore\BackendUi\WorkerErrorLogAggregator;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class WorkerErrorLog implements ProtectedContextAwareInterface
+{
+    private string $workerName;
+    private string $status;
+    private int $exitCode;
+    private ?string $taskError;
+    private ?string $lastAttemptedNode;
+
+    /**
+     * @var string[]
+     */
+    private array $errorBlocks;
+
+    /**
+     * @param string[] $errorBlocks
+     */
+    public function __construct(
+        string $workerName,
+        string $status,
+        int $exitCode,
+        ?string $taskError,
+        array $errorBlocks,
+        ?string $lastAttemptedNode = null
+    ) {
+        $this->workerName = $workerName;
+        $this->status = $status;
+        $this->exitCode = $exitCode;
+        $this->taskError = $taskError;
+        $this->errorBlocks = $errorBlocks;
+        $this->lastAttemptedNode = $lastAttemptedNode;
+    }
+
+    public function getWorkerName(): string
+    {
+        return $this->workerName;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getExitCode(): int
+    {
+        return $this->exitCode;
+    }
+
+    public function getTaskError(): ?string
+    {
+        return $this->taskError;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrorBlocks(): array
+    {
+        return $this->errorBlocks;
+    }
+
+    public function getLastAttemptedNode(): ?string
+    {
+        return $this->lastAttemptedNode;
+    }
+
+    public function wasKilledByOrchestrator(): bool
+    {
+        return $this->exitCode === WorkerErrorLogAggregator::EXIT_CODE_SIGTERM;
+    }
+
+    public function allowsCallOfMethod($methodName): bool
+    {
+        return true;
+    }
+}

--- a/Classes/BackendUi/Dto/WorkerErrorLog.php
+++ b/Classes/BackendUi/Dto/WorkerErrorLog.php
@@ -11,78 +11,21 @@ use Neos\Flow\Annotations as Flow;
 /**
  * @Flow\Proxy(false)
  */
-final class WorkerErrorLog implements ProtectedContextAwareInterface
+final class WorkerErrorLog
 {
-    private string $workerName;
-    private string $status;
-    private int $exitCode;
-    private ?string $taskError;
-    private ?string $lastAttemptedNode;
-
-    /**
-     * @var string[]
-     */
-    private array $errorBlocks;
+    public bool $wasKilledByOrchestrator;
 
     /**
      * @param string[] $errorBlocks
      */
     public function __construct(
-        string $workerName,
-        string $status,
-        int $exitCode,
-        ?string $taskError,
-        array $errorBlocks,
-        ?string $lastAttemptedNode = null
+        public string $workerName,
+        public string $status,
+        public int $exitCode,
+        public ?string $taskError,
+        public array $errorBlocks,
+        public ?string $lastAttemptedNode = null
     ) {
-        $this->workerName = $workerName;
-        $this->status = $status;
-        $this->exitCode = $exitCode;
-        $this->taskError = $taskError;
-        $this->errorBlocks = $errorBlocks;
-        $this->lastAttemptedNode = $lastAttemptedNode;
-    }
-
-    public function getWorkerName(): string
-    {
-        return $this->workerName;
-    }
-
-    public function getStatus(): string
-    {
-        return $this->status;
-    }
-
-    public function getExitCode(): int
-    {
-        return $this->exitCode;
-    }
-
-    public function getTaskError(): ?string
-    {
-        return $this->taskError;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getErrorBlocks(): array
-    {
-        return $this->errorBlocks;
-    }
-
-    public function getLastAttemptedNode(): ?string
-    {
-        return $this->lastAttemptedNode;
-    }
-
-    public function wasKilledByOrchestrator(): bool
-    {
-        return $this->exitCode === WorkerErrorLogAggregator::EXIT_CODE_SIGTERM;
-    }
-
-    public function allowsCallOfMethod($methodName): bool
-    {
-        return true;
+        $this->wasKilledByOrchestrator = $this->exitCode === WorkerErrorLogAggregator::EXIT_CODE_SIGTERM;
     }
 }

--- a/Classes/BackendUi/RenderingErrorExtractor.php
+++ b/Classes/BackendUi/RenderingErrorExtractor.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\DecoupledContentStore\BackendUi;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class RenderingErrorExtractor
+{
+    /**
+     * Extracts ERROR-prefixed lines and exception blocks from a raw log string.
+     *
+     * Log format produced by ContentReleaseLogger:
+     *  - error()         => single line "[Renderer X] ERROR <message> [<json>]"
+     *  - logException()  => one writeln with "<header>\n\n<msg>\n\n<trace>\n\n<json>"
+     *
+     * Strategy: split on blank lines into paragraphs; keep paragraphs that
+     * contain an ERROR-prefixed line or PHP stack-trace markers, and also
+     * include the paragraph immediately before a stack-trace paragraph (that
+     * paragraph carries the exception message in logException output).
+     *
+     * @return string[]
+     */
+    public function extractErrorBlocks(string $log): array
+    {
+        $log = trim($log);
+        if ($log === '') {
+            return [];
+        }
+
+        $paragraphs = preg_split('/\n\s*\n/', $log) ?: [];
+        $hits = [];
+        foreach ($paragraphs as $index => $paragraph) {
+            $hasError = (bool)preg_match('/(?:^|] )ERROR /m', $paragraph);
+            $hasTrace = (bool)preg_match('/^#\d+ /m', $paragraph);
+            if (!$hasError && !$hasTrace) {
+                continue;
+            }
+            if ($hasTrace && $index > 0 && !isset($hits[$index - 1])) {
+                $previous = $paragraphs[$index - 1];
+                if (trim($previous) !== '') {
+                    $hits[$index - 1] = $previous;
+                }
+            }
+            $hits[$index] = $paragraph;
+        }
+
+        if ($hits !== []) {
+            return $hits;
+        }
+
+        // No structured ERROR/trace matched. Drop INFO/DEBUG/NOTICE/WARN lines
+        // (with or without an optional "[prefix] " section) plus a few known
+        // operational status messages, and return whatever remains as a single
+        // block — covers logs that use unfamiliar formats but still mark their
+        // noise levels.
+        $kept = [];
+        foreach (explode("\n", $log) as $line) {
+            if (preg_match('/^\s*(?:\[[^]]+]\s*)?(?:INFO|DEBUG|NOTICE|WARN(?:ING)?)\b/', $line)) {
+                continue;
+            }
+            if (preg_match('/Restarting render worker\.?/', $line)) {
+                continue;
+            }
+            $kept[] = $line;
+        }
+        $remaining = trim(implode("\n", $kept));
+        return $remaining === '' ? [] : [$remaining];
+    }
+
+    /**
+     * Returns the last node reference found in a worker log — the one the
+     * worker was rendering when it failed.
+     *
+     * NodeRenderer logs a DEBUG line "Rendering document node variant" before
+     * each render and a logException(...) entry on failure; both include the
+     * node identifier in the JSON payload. The very last "node":"..." match in
+     * the log is therefore the most likely failing node, whether the worker
+     * threw an exception or got killed mid-render.
+     */
+    public function extractLastAttemptedNode(string $log): ?string
+    {
+        if (trim($log) === '') {
+            return null;
+        }
+
+        if (!preg_match_all(
+            '/"node"\s*:\s*"((?:\\\\.|[^"\\\\])*)"(?:\s*,\s*"nodeUri"\s*:\s*"((?:\\\\.|[^"\\\\])*)")?/',
+            $log,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            return null;
+        }
+
+        $last = end($matches);
+        $node = $this->decodeJsonString($last[1]);
+        $uri = isset($last[2]) ? $this->decodeJsonString($last[2]) : '';
+        return $uri !== '' ? sprintf('%s | %s', $node, $uri) : $node;
+    }
+
+    private function decodeJsonString(string $raw): string
+    {
+        $decoded = json_decode('"' . $raw . '"');
+        return is_string($decoded) ? $decoded : str_replace('\\/', '/', $raw);
+    }
+}

--- a/Classes/BackendUi/WorkerErrorLogAggregator.php
+++ b/Classes/BackendUi/WorkerErrorLogAggregator.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\DecoupledContentStore\BackendUi;
+
+use Flowpack\DecoupledContentStore\BackendUi\Dto\WorkerErrorLog;
+use Flowpack\Prunner\Dto\Job;
+use Flowpack\Prunner\Dto\TaskResult;
+use Flowpack\Prunner\PrunnerApiService;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class WorkerErrorLogAggregator
+{
+    /**
+     * @Flow\Inject
+     * @var PrunnerApiService
+     */
+    protected $prunnerApiService;
+
+    /**
+     * @Flow\Inject
+     * @var RenderingErrorExtractor
+     */
+    protected $renderingErrorExtractor;
+
+    /**
+     * Exit code 143 = 128 + SIGTERM(15): orchestrator killed this worker after another one failed.
+     */
+    public const EXIT_CODE_SIGTERM = 143;
+
+    /**
+     * @return WorkerErrorLog[]
+     */
+    public function aggregate(Job $job): array
+    {
+        $renderTasks = $job->getTaskResults()
+            ->filteredByPrefix('render_')
+            ->withoutTasks('render_finished', 'render_orchestrator');
+
+        $erroredTasks = [];
+        foreach ($renderTasks as $task) {
+            if ($task->getStatus() === TaskResult::STATUS_ERROR) {
+                $erroredTasks[] = $task;
+            }
+        }
+
+        if ($erroredTasks === []) {
+            $orchestrator = $job->getTaskResults()->get('render_orchestrator');
+            if ($orchestrator !== null && $orchestrator->getStatus() === TaskResult::STATUS_ERROR) {
+                $erroredTasks[] = $orchestrator;
+            }
+        }
+
+        // Real failures (non-SIGTERM) carry the actual error — show them first.
+        usort($erroredTasks, static function (TaskResult $a, TaskResult $b): int {
+            return ($a->getExitCode() === self::EXIT_CODE_SIGTERM ? 1 : 0)
+                <=> ($b->getExitCode() === self::EXIT_CODE_SIGTERM ? 1 : 0);
+        });
+
+        $result = [];
+        foreach ($erroredTasks as $task) {
+            $blocks = [];
+            $lastAttemptedNode = null;
+            if ($task->getExitCode() !== self::EXIT_CODE_SIGTERM) {
+                $logs = $this->prunnerApiService->loadJobLogs($job->getId(), $task->getName());
+                $combined = $logs->getStderr() . "\n" . $logs->getStdout();
+                $blocks = $this->renderingErrorExtractor->extractErrorBlocks($combined);
+                $lastAttemptedNode = $this->renderingErrorExtractor->extractLastAttemptedNode($combined);
+            }
+
+            $result[] = new WorkerErrorLog(
+                $task->getName(),
+                $task->getStatus(),
+                $task->getExitCode(),
+                $task->getError() ?: null,
+                $blocks,
+                $lastAttemptedNode
+            );
+        }
+
+        return $result;
+    }
+}

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -2,6 +2,7 @@
 namespace Flowpack\DecoupledContentStore\Controller;
 
 use Flowpack\DecoupledContentStore\BackendUi\BackendUiDataService;
+use Flowpack\DecoupledContentStore\BackendUi\WorkerErrorLogAggregator;
 use Flowpack\DecoupledContentStore\ContentReleaseManager;
 use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\ContentReleaseIdentifier;
 use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\PrunnerJobId;
@@ -39,6 +40,12 @@ class BackendController extends \Neos\Flow\Mvc\Controller\ActionController
      * @var BackendUiDataService
      */
     protected $backendUiDataService;
+
+    /**
+     * @Flow\Inject
+     * @var WorkerErrorLogAggregator
+     */
+    protected $workerErrorLogAggregator;
 
     /**
      * @Flow\Inject
@@ -109,7 +116,7 @@ class BackendController extends \Neos\Flow\Mvc\Controller\ActionController
         $this->view->assign('showToggleConfigEpochButton', $showToggleConfigEpochButton);
     }
 
-    public function detailsAction(string $contentReleaseIdentifier, ?string $contentStore = null, ?string $detailTaskName = '', ?string $prunnerJobId = '')
+    public function detailsAction(string $contentReleaseIdentifier, ?string $contentStore = null, ?string $detailTaskName = '', ?string $prunnerJobId = '', bool $showAllRenderingErrors = false)
     {
         $contentReleaseIdentifier = ContentReleaseIdentifier::fromString($contentReleaseIdentifier);
         $contentStore = $contentStore ? RedisInstanceIdentifier::fromString($contentStore) : RedisInstanceIdentifier::primary();
@@ -125,6 +132,8 @@ class BackendController extends \Neos\Flow\Mvc\Controller\ActionController
         if ($detailTaskName !== '') {
             $this->view->assign('detailTaskName', $detailTaskName);
             $this->view->assign('jobLogs', $this->prunnerApiService->loadJobLogs($prunnerJobId ? PrunnerJobId::fromString($prunnerJobId)->toJobId() : $detailsData->getJob()->getId(), $detailTaskName));
+        } elseif ($showAllRenderingErrors && $detailsData->getJob() !== null) {
+            $this->view->assign('workerErrorLogs', $this->workerErrorLogAggregator->aggregate($detailsData->getJob()));
         }
     }
 

--- a/Resources/Private/BackendFusion/Integration/Backend.Details.fusion
+++ b/Resources/Private/BackendFusion/Integration/Backend.Details.fusion
@@ -53,6 +53,10 @@ Flowpack.DecoupledContentStore.BackendController.details = Neos.Fusion:Component
             <p @if.notData={!detailsData}>
               No data exists for this release in Redis.
             </p>
+            <Flowpack.DecoupledContentStore:AggregatedRenderingErrors
+                    @if.hasErrorLogs={workerErrorLogs}
+                    workerErrorLogs={workerErrorLogs}
+            />
         </div>
         <Flowpack.DecoupledContentStore:DetailsFooter />
     `
@@ -137,6 +141,10 @@ prototype(Flowpack.DecoupledContentStore:ContentReleaseSteps) < prototype(Neos.F
                     </Neos.Fusion:Loop>
                 </div>
                 <div class="pl-5 pr-10 py-2 flex justify-end">
+                    <Flowpack.DecoupledContentStore:ContentReleaseSteps.AllRenderingErrorsButton
+                            @if.hasError={props._taskResults.filteredByPrefix('render_').aggregatedStatus == 'error'}
+                            prunnerJobId={props.prunnerJobId}
+                    />
                     <Flowpack.DecoupledContentStore:ContentReleaseSteps.StepTask
                             task={props._taskResults.get('render_orchestrator')}
                             title="orchestrator"
@@ -327,6 +335,69 @@ prototype(Flowpack.DecoupledContentStore:ContentReleaseSteps.StepTask) < prototy
            class={"inline-flex items-center mx-1 px-2.5 py-0.5 rounded-full border-2 text-xs font-medium text-white " + props._statusClass}>
             {props.title}
         </a>
+    `
+}
+
+prototype(Flowpack.DecoupledContentStore:ContentReleaseSteps.AllRenderingErrorsButton) < prototype(Neos.Fusion:Component) {
+    prunnerJobId = ''
+
+    _href = Neos.Fusion:UriBuilder {
+        action = 'details'
+        arguments.showAllRenderingErrors = 1
+        arguments.detailTaskName = ''
+        arguments.prunnerJobId = ${props.prunnerJobId}
+        addQueryString = true
+    }
+
+    renderer = afx`
+        <a href={props._href} title="Show ERROR logs from all failed workers"
+           class="inline-flex items-center mx-1 px-2.5 py-0.5 rounded-full border-2 text-xs font-medium text-white bg-red-500 border-red-500">
+            all errors
+        </a>
+    `
+}
+
+prototype(Flowpack.DecoupledContentStore:AggregatedRenderingErrors) < prototype(Neos.Fusion:Component) {
+    workerErrorLogs = null
+
+    renderer = afx`
+        <h2 class="text-3xl py-5">Rendering errors across all workers</h2>
+        <Neos.Fusion:Loop items={props.workerErrorLogs} itemName="workerErrorLog">
+            <Flowpack.DecoupledContentStore:AggregatedRenderingErrors.WorkerEntry workerErrorLog={workerErrorLog} />
+        </Neos.Fusion:Loop>
+    `
+}
+
+prototype(Flowpack.DecoupledContentStore:AggregatedRenderingErrors.WorkerEntry) < prototype(Neos.Fusion:Component) {
+    workerErrorLog = null
+
+    _statusClass = ${this.workerErrorLog.status}
+    _statusClass.@process.replace = Flowpack.DecoupledContentStore:StatusToClassMapping
+
+    renderer = afx`
+        <div class={(props.workerErrorLog.wasKilledByOrchestrator() ? 'my-1 p-2 ' : 'my-4 p-4 ') + 'bg-white shadow rounded-lg text-gray-900'}>
+            <div class="flex items-center mb-2">
+                <span class={"inline-flex items-center mr-2 px-2.5 py-0.5 rounded-full border-2 text-xs font-medium text-white " + props._statusClass}>
+                    {props.workerErrorLog.status}
+                </span>
+                <span class="font-mono text-sm text-gray-900 mr-2">{props.workerErrorLog.workerName}</span>
+                <span class="text-xs text-gray-500">exit {props.workerErrorLog.exitCode}</span>
+                <span @if.killed={props.workerErrorLog.wasKilledByOrchestrator()} class="ml-2 text-xs text-gray-500 italic">
+                    killed by orchestrator after another worker failed
+                </span>
+            </div>
+            <p @if.hasTaskError={props.workerErrorLog.taskError && !props.workerErrorLog.wasKilledByOrchestrator()} class="text-sm text-red-700 mb-2">{props.workerErrorLog.taskError}</p>
+            <div @if.hasNode={props.workerErrorLog.lastAttemptedNode} class="mb-3 p-3 bg-red-100 border-l-4 border-red-500 rounded">
+                <p class="text-xs font-semibold text-red-800 mb-1 uppercase tracking-wide">Last node attempted before failure</p>
+                <p class="text-sm text-gray-900 font-mono break-all">{props.workerErrorLog.lastAttemptedNode}</p>
+            </div>
+            <Neos.Fusion:Loop items={props.workerErrorLog.errorBlocks} itemName="block">
+                <pre class="text-gray-900 bg-gray-100 p-3 rounded text-xs overflow-x-auto whitespace-pre-wrap mb-2">{block}</pre>
+            </Neos.Fusion:Loop>
+            <p @if.noBlocks={!props.workerErrorLog.errorBlocks && !props.workerErrorLog.wasKilledByOrchestrator() && !props.workerErrorLog.taskError} class="text-sm text-gray-500 italic">
+                No log output from this worker.
+            </p>
+        </div>
     `
 }
 

--- a/Resources/Private/BackendFusion/Integration/Backend.Details.fusion
+++ b/Resources/Private/BackendFusion/Integration/Backend.Details.fusion
@@ -375,18 +375,18 @@ prototype(Flowpack.DecoupledContentStore:AggregatedRenderingErrors.WorkerEntry) 
     _statusClass.@process.replace = Flowpack.DecoupledContentStore:StatusToClassMapping
 
     renderer = afx`
-        <div class={(props.workerErrorLog.wasKilledByOrchestrator() ? 'my-1 p-2 ' : 'my-4 p-4 ') + 'bg-white shadow rounded-lg text-gray-900'}>
+        <div class={(props.workerErrorLog.wasKilledByOrchestrator ? 'my-1 p-2 ' : 'my-4 p-4 ') + 'bg-white shadow rounded-lg text-gray-900'}>
             <div class="flex items-center mb-2">
                 <span class={"inline-flex items-center mr-2 px-2.5 py-0.5 rounded-full border-2 text-xs font-medium text-white " + props._statusClass}>
                     {props.workerErrorLog.status}
                 </span>
                 <span class="font-mono text-sm text-gray-900 mr-2">{props.workerErrorLog.workerName}</span>
                 <span class="text-xs text-gray-500">exit {props.workerErrorLog.exitCode}</span>
-                <span @if.killed={props.workerErrorLog.wasKilledByOrchestrator()} class="ml-2 text-xs text-gray-500 italic">
+                <span @if.killed={props.workerErrorLog.wasKilledByOrchestrator} class="ml-2 text-xs text-gray-500 italic">
                     killed by orchestrator after another worker failed
                 </span>
             </div>
-            <p @if.hasTaskError={props.workerErrorLog.taskError && !props.workerErrorLog.wasKilledByOrchestrator()} class="text-sm text-red-700 mb-2">{props.workerErrorLog.taskError}</p>
+            <p @if.hasTaskError={props.workerErrorLog.taskError && !props.workerErrorLog.wasKilledByOrchestrator} class="text-sm text-red-700 mb-2">{props.workerErrorLog.taskError}</p>
             <div @if.hasNode={props.workerErrorLog.lastAttemptedNode} class="mb-3 p-3 bg-red-100 border-l-4 border-red-500 rounded">
                 <p class="text-xs font-semibold text-red-800 mb-1 uppercase tracking-wide">Last node attempted before failure</p>
                 <p class="text-sm text-gray-900 font-mono break-all">{props.workerErrorLog.lastAttemptedNode}</p>
@@ -394,7 +394,7 @@ prototype(Flowpack.DecoupledContentStore:AggregatedRenderingErrors.WorkerEntry) 
             <Neos.Fusion:Loop items={props.workerErrorLog.errorBlocks} itemName="block">
                 <pre class="text-gray-900 bg-gray-100 p-3 rounded text-xs overflow-x-auto whitespace-pre-wrap mb-2">{block}</pre>
             </Neos.Fusion:Loop>
-            <p @if.noBlocks={!props.workerErrorLog.errorBlocks && !props.workerErrorLog.wasKilledByOrchestrator() && !props.workerErrorLog.taskError} class="text-sm text-gray-500 italic">
+            <p @if.noBlocks={!props.workerErrorLog.errorBlocks && !props.workerErrorLog.wasKilledByOrchestrator && !props.workerErrorLog.taskError} class="text-sm text-gray-500 italic">
                 No log output from this worker.
             </p>
         </div>

--- a/Resources/Public/BackendCompiled/out.css
+++ b/Resources/Public/BackendCompiled/out.css
@@ -1,4 +1,4 @@
-/* ../../../../../../../../../var/folders/1z/rq1_kd710hn00r35j5rzqs5h0000gn/T/tmp-24630-ZfKI51gf2y1c/Flowpack.DecoupledContentStore/Resources/Private/Js/1705488391983-styles.css */
+/* ../../../../../../../../private/var/folders/fd/vt4bk4351l97704fxm4zmmyr0000gn/T/tmp-47815-zvlMZoCh5PYD/Flowpack.DecoupledContentStore/Resources/Private/Js/1778224314767-styles.css */
 #app *,
 #app ::before,
 #app ::after {
@@ -17,31 +17,51 @@
 #app .relative {
   position: relative;
 }
-#app .top-0 {
-  top: 0px;
+#app .bottom-0 {
+  bottom: 0px;
 }
 #app .right-0 {
   right: 0px;
 }
-#app .bottom-0 {
-  bottom: 0px;
+#app .top-0 {
+  top: 0px;
 }
 #app .mx-1 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
 }
+#app .my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+#app .my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
 #app .my-5 {
   margin-top: 1.25rem;
   margin-bottom: 1.25rem;
 }
+#app .mb-1 {
+  margin-bottom: 0.25rem;
+}
+#app .mb-2 {
+  margin-bottom: 0.5rem;
+}
+#app .mb-3 {
+  margin-bottom: 0.75rem;
+}
 #app .mb-6 {
   margin-bottom: 1.5rem;
 }
-#app .mt-4 {
-  margin-top: 1rem;
+#app .ml-2 {
+  margin-left: 0.5rem;
 }
 #app .ml-4 {
   margin-left: 1rem;
+}
+#app .mr-2 {
+  margin-right: 0.5rem;
 }
 #app .mr-5 {
   margin-right: 1.25rem;
@@ -49,8 +69,8 @@
 #app .mt-1 {
   margin-top: 0.25rem;
 }
-#app .mb-2 {
-  margin-bottom: 0.5rem;
+#app .mt-4 {
+  margin-top: 1rem;
 }
 #app .block {
   display: block;
@@ -79,14 +99,14 @@
 #app .h-10 {
   height: 2.5rem;
 }
-#app .w-full {
-  width: 100%;
-}
 #app .w-10 {
   width: 2.5rem;
 }
 #app .w-5 {
   width: 1.25rem;
+}
+#app .w-full {
+  width: 100%;
 }
 #app .flex-1 {
   flex: 1 1 0%;
@@ -94,18 +114,12 @@
 #app .flex-shrink-0 {
   flex-shrink: 0;
 }
-@-webkit-keyframes pulse {
-  50% {
-    opacity: .5;
-  }
-}
 @keyframes pulse {
   50% {
     opacity: .5;
   }
 }
 #app .animate-pulse {
-  -webkit-animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 #app .flex-col {
@@ -123,17 +137,20 @@
 #app .gap-2 {
   gap: 0.5rem;
 }
-#app .divide-y > :not([hidden]) ~ :not([hidden]) {
+#app :is(.divide-y > :not([hidden]) ~ :not([hidden])) {
   --tw-divide-y-reverse: 0;
   border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
   border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
 }
-#app .divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
+#app :is(.divide-gray-300 > :not([hidden]) ~ :not([hidden])) {
   --tw-divide-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-divide-opacity));
+  border-color: rgb(209 213 219 / var(--tw-divide-opacity, 1));
 }
 #app .overflow-hidden {
   overflow: hidden;
+}
+#app .overflow-x-auto {
+  overflow-x: auto;
 }
 #app .overflow-x-scroll {
   overflow-x: scroll;
@@ -146,8 +163,14 @@
 #app .whitespace-pre {
   white-space: pre;
 }
-#app .rounded-md {
-  border-radius: 0.375rem;
+#app .whitespace-pre-wrap {
+  white-space: pre-wrap;
+}
+#app .break-all {
+  word-break: break-all;
+}
+#app .rounded {
+  border-radius: 0.25rem;
 }
 #app .rounded-full {
   border-radius: 9999px;
@@ -155,102 +178,114 @@
 #app .rounded-lg {
   border-radius: 0.5rem;
 }
+#app .rounded-md {
+  border-radius: 0.375rem;
+}
 #app .border {
   border-width: 1px;
 }
 #app .border-2 {
   border-width: 2px;
 }
-#app .border-red-800 {
-  --tw-border-opacity: 1;
-  border-color: rgb(153 27 27 / var(--tw-border-opacity));
+#app .border-l-4 {
+  border-left-width: 4px;
 }
 #app .border-gray-300 {
   --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
-}
-#app .border-green-400 {
-  --tw-border-opacity: 1;
-  border-color: rgb(74 222 128 / var(--tw-border-opacity));
-}
-#app .border-yellow-400 {
-  --tw-border-opacity: 1;
-  border-color: rgb(250 204 21 / var(--tw-border-opacity));
-}
-#app .border-red-500 {
-  --tw-border-opacity: 1;
-  border-color: rgb(239 68 68 / var(--tw-border-opacity));
+  border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
 }
 #app .border-gray-500 {
   --tw-border-opacity: 1;
-  border-color: rgb(107 114 128 / var(--tw-border-opacity));
+  border-color: rgb(107 114 128 / var(--tw-border-opacity, 1));
 }
-#app .bg-gray-700 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(55 65 81 / var(--tw-bg-opacity));
+#app .border-green-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(74 222 128 / var(--tw-border-opacity, 1));
 }
-#app .bg-white {
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+#app .border-red-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity, 1));
 }
-#app .bg-green-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(74 222 128 / var(--tw-bg-opacity));
+#app .border-red-800 {
+  --tw-border-opacity: 1;
+  border-color: rgb(153 27 27 / var(--tw-border-opacity, 1));
 }
-#app .bg-yellow-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(250 204 21 / var(--tw-bg-opacity));
-}
-#app .bg-red-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
-}
-#app .bg-gray-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
+#app .border-yellow-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(250 204 21 / var(--tw-border-opacity, 1));
 }
 #app .bg-blue-300 {
   --tw-bg-opacity: 1;
-  background-color: rgb(147 197 253 / var(--tw-bg-opacity));
+  background-color: rgb(147 197 253 / var(--tw-bg-opacity, 1));
+}
+#app .bg-gray-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+}
+#app .bg-gray-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
+}
+#app .bg-gray-700 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(55 65 81 / var(--tw-bg-opacity, 1));
+}
+#app .bg-green-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(74 222 128 / var(--tw-bg-opacity, 1));
+}
+#app .bg-red-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity, 1));
+}
+#app .bg-red-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
+}
+#app .bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+#app .bg-yellow-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 204 21 / var(--tw-bg-opacity, 1));
 }
 #app .p-2 {
   padding: 0.5rem;
 }
-#app .py-5 {
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
+#app .p-3 {
+  padding: 0.75rem;
 }
-#app .py-2 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
-#app .px-6 {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-}
-#app .py-4 {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+#app .p-4 {
+  padding: 1rem;
 }
 #app .px-2\.5 {
   padding-left: 0.625rem;
   padding-right: 0.625rem;
 }
+#app .px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
 #app .py-0\.5 {
   padding-top: 0.125rem;
   padding-bottom: 0.125rem;
 }
-#app .px-2 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-#app .py-0 {
-  padding-top: 0px;
-  padding-bottom: 0px;
+#app .py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 #app .py-3 {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
+}
+#app .py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+#app .py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
 }
 #app .pl-5 {
   padding-left: 1.25rem;
@@ -260,6 +295,17 @@
 }
 #app .pt-2 {
   padding-top: 0.5rem;
+}
+#app .font-mono {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
 }
 #app .text-3xl {
   font-size: 1.875rem;
@@ -279,24 +325,41 @@
 #app .font-semibold {
   font-weight: 600;
 }
+#app .uppercase {
+  text-transform: uppercase;
+}
+#app .italic {
+  font-style: italic;
+}
 #app .leading-6 {
   line-height: 1.5rem;
 }
-#app .text-white {
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
+#app .tracking-wide {
+  letter-spacing: 0.025em;
 }
 #app .text-gray-300 {
   --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity));
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
 #app .text-gray-500 {
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 #app .text-gray-900 {
   --tw-text-opacity: 1;
-  color: rgb(17 24 39 / var(--tw-text-opacity));
+  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
+}
+#app .text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
+}
+#app .text-red-800 {
+  --tw-text-opacity: 1;
+  color: rgb(153 27 27 / var(--tw-text-opacity, 1));
+}
+#app .text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 #app .shadow {
   --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
@@ -324,7 +387,7 @@
   #app .md\:flex-1 {
     flex: 1 1 0%;
   }
-  #app .md\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
+  #app :is(.md\:divide-y-0 > :not([hidden]) ~ :not([hidden])) {
     --tw-divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--tw-divide-y-reverse)));
     border-bottom-width: calc(0px * var(--tw-divide-y-reverse));


### PR DESCRIPTION
This adds a button besides the orchestrator button in the Content Release detail page. It is only shown when a worker has an error.

After clicking on the button a new content window appears below and shows only the error output (omits info, debug and general noise) so you can see the error that occurred with one click.

<img width="3310" height="778" alt="Screenshot 2026-05-08 at 14 13 30" src="https://github.com/user-attachments/assets/fcaefb24-49c6-47b9-a8c2-1f1bafc353a0" />
