### PR TITLE
BUGFIX: Recover from missing "doc--..." mapping entries instead of looping

### DIFF
--- a/Classes/Aspects/CacheUrlMappingAspect.php
+++ b/Classes/Aspects/CacheUrlMappingAspect.php
@@ -81,6 +81,13 @@ class CacheUrlMappingAspect
     protected $contentReleaseLogger;
 
     /**
+     * Did the current document rendering lead to a "doc--..." mapping entry? {@see afterDocumentRendering()}
+     *
+     * @var bool
+     */
+    protected $mappingWasWrittenForCurrentDocument = false;
+
+    /**
      * @Flow\Before("method(Neos\Fusion\Core\Cache\RuntimeContentCache->postProcess())")
      */
     public function getCurrentEvaluateAndControllerContext(JoinPointInterface $joinPoint)
@@ -153,6 +160,7 @@ class CacheUrlMappingAspect
         // allow other document metadata generators here
         $rootCacheValues = $this->nodeRenderingExtensionManager->runDocumentMetadataGenerators($node, $arguments, $this->controllerContext, $rootCacheValues);
         $this->contentCacheFrontend->set($rootKey->redisKeyName(), json_encode($rootCacheValues), $rootTags);
+        $this->mappingWasWrittenForCurrentDocument = true;
     }
 
     /**
@@ -207,11 +215,21 @@ class CacheUrlMappingAspect
         $this->isActive = true;
         $this->contentReleaseLogger = $contentReleaseLogger;
         $this->renderTimestamp = (int)(microtime(true) * 1000);
+        $this->mappingWasWrittenForCurrentDocument = false;
     }
 
     public function afterDocumentRendering(): void
     {
+        // Without a mapping entry, the NodeRenderOrchestrator can never see this document as rendered, and will
+        // schedule it again in the next iteration. Most ways of getting here are silent (no exception, no rendering
+        // error), so we make some noise - otherwise the content release just fails with the retry limit and no hint
+        // about the reason. {@see storeRootCacheIdentifier()}
+        if (!$this->mappingWasWrittenForCurrentDocument && $this->contentReleaseLogger !== null) {
+            $this->contentReleaseLogger->warn('No "doc--..." mapping entry was written for this rendering, so it can never be added to the content release. Either the rendering was fully served from the content cache (then the content cache entries of this node need to be flushed before re-rendering), or its URL is excluded via nodeRendering.urlExcludelistRegex while the node is still part of the enumeration.');
+        }
+
         $this->isActive = false;
         $this->contentReleaseLogger = null;
+        $this->mappingWasWrittenForCurrentDocument = false;
     }
 }

--- a/Classes/NodeRendering/Infrastructure/RedisRenderingQueue.php
+++ b/Classes/NodeRendering/Infrastructure/RedisRenderingQueue.php
@@ -77,6 +77,22 @@ class RedisRenderingQueue
     }
 
     /**
+     * Counts how often the given node has been handed out for rendering within this content release, and returns
+     * the number of the attempt which is about to start (1 for the first attempt).
+     *
+     * A node which is handed out more than once means the previous rendering did not lead to a complete content
+     * cache entry, {@see \Flowpack\DecoupledContentStore\NodeRendering\NodeRenderOrchestrator}.
+     */
+    public function registerRenderingAttempt(ContentReleaseIdentifier $contentReleaseIdentifier, EnumeratedNode $enumeratedNode): int
+    {
+        return (int)$this->redisClientManager->getPrimaryRedis()->hIncrBy(
+            $this->redisKeyService->getRedisKeyForPostfix($contentReleaseIdentifier, 'renderAttempts'),
+            json_encode($enumeratedNode),
+            1
+        );
+    }
+
+    /**
      * @param ContentReleaseIdentifier $contentReleaseIdentifier
      * @param EnumeratedNode $enumeratedNode
      * @param RendererIdentifier $rendererIdentifier
@@ -109,6 +125,6 @@ class RedisRenderingQueue
 
     public function flush(ContentReleaseIdentifier $contentReleaseIdentifier)
     {
-        $this->redisClientManager->getPrimaryRedis()->del($this->redisKeyService->getRedisKeyForPostfix($contentReleaseIdentifier, 'renderingJobQueue'), $this->redisKeyService->getRedisKeyForPostfix($contentReleaseIdentifier, 'inProgressRenderings'));
+        $this->redisClientManager->getPrimaryRedis()->del($this->redisKeyService->getRedisKeyForPostfix($contentReleaseIdentifier, 'renderingJobQueue'), $this->redisKeyService->getRedisKeyForPostfix($contentReleaseIdentifier, 'inProgressRenderings'), $this->redisKeyService->getRedisKeyForPostfix($contentReleaseIdentifier, 'renderAttempts'));
     }
 }

--- a/Classes/NodeRendering/NodeRenderOrchestrator.php
+++ b/Classes/NodeRendering/NodeRenderOrchestrator.php
@@ -5,22 +5,22 @@ declare(strict_types=1);
 namespace Flowpack\DecoupledContentStore\NodeRendering;
 
 use Flowpack\DecoupledContentStore\Core\ConcurrentBuildLockService;
+use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\ContentReleaseIdentifier;
 use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\RedisInstanceIdentifier;
+use Flowpack\DecoupledContentStore\Core\Infrastructure\ContentReleaseLogger;
+use Flowpack\DecoupledContentStore\NodeEnumeration\Domain\Dto\EnumeratedNode;
+use Flowpack\DecoupledContentStore\NodeEnumeration\Domain\Repository\RedisEnumerationRepository;
+use Flowpack\DecoupledContentStore\NodeRendering\Dto\NodeRenderingCompletionStatus;
 use Flowpack\DecoupledContentStore\NodeRendering\Dto\RenderingStatistics;
 use Flowpack\DecoupledContentStore\NodeRendering\Extensibility\NodeRenderingExtensionManager;
 use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingErrorManager;
+use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingQueue;
 use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingTimeStatisticsStore;
 use Flowpack\DecoupledContentStore\NodeRendering\ProcessEvents\ExitEvent;
 use Flowpack\DecoupledContentStore\NodeRendering\ProcessEvents\RenderingIterationCompletedEvent;
 use Flowpack\DecoupledContentStore\NodeRendering\ProcessEvents\RenderingQueueFilledEvent;
 use Flowpack\DecoupledContentStore\PrepareContentRelease\Infrastructure\RedisContentReleaseService;
 use Neos\Flow\Annotations as Flow;
-use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\ContentReleaseIdentifier;
-use Flowpack\DecoupledContentStore\Core\Infrastructure\ContentReleaseLogger;
-use Flowpack\DecoupledContentStore\NodeEnumeration\Domain\Dto\EnumeratedNode;
-use Flowpack\DecoupledContentStore\NodeEnumeration\Domain\Repository\RedisEnumerationRepository;
-use Flowpack\DecoupledContentStore\NodeRendering\Dto\NodeRenderingCompletionStatus;
-use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingQueue;
 
 /**
  * TODO: explain concept of Working Set
@@ -98,6 +98,13 @@ class NodeRenderOrchestrator
     private const EXIT_ERRORSTATUSCODE_RENDERING_ERRORS = 4;
 
     /**
+     * How often the very same set of nodes may be scheduled in a row before we give up on them. The rendering gets
+     * one real retry (which flushes the content cache for these nodes, {@see NodeRenderer::flushContentCacheForNode()})
+     * before this kicks in.
+     */
+    private const MAX_ITERATIONS_WITHOUT_PROGRESS = 3;
+
+    /**
      * !!! You need to wrap this in the {@see InterruptibleProcessRuntime} so that it works correctly.
      *
      * @param ContentReleaseIdentifier $contentReleaseIdentifier
@@ -129,6 +136,9 @@ class NodeRenderOrchestrator
         }
 
         $currentEnumeration = $this->redisEnumerationRepository->findAll($contentReleaseIdentifier);
+
+        $previouslyScheduledNodes = null;
+        $identicalIterationCount = 0;
 
         $i = 0;
         do {
@@ -180,6 +190,45 @@ class NodeRenderOrchestrator
 
                 // Exit successfully.
                 yield ExitEvent::createWithStatusCode(0);
+                return;
+            }
+
+            // If an iteration schedules exactly the same nodes as the previous one, the renderings did not get us any
+            // closer to a complete content release. Retrying this until the retry limit is reached only wastes time -
+            // and (because no exception happened) leaves no trace anywhere. So we register a rendering error naming
+            // these nodes, which makes them visible in the Backend UI.
+            $scheduledNodes = array_map(fn(EnumeratedNode $enumeratedNode) => json_encode($enumeratedNode),
+                $nodesScheduledForRendering);
+            sort($scheduledNodes);
+            $identicalIterationCount = $scheduledNodes === $previouslyScheduledNodes ? $identicalIterationCount + 1 : 1;
+            $previouslyScheduledNodes = $scheduledNodes;
+
+            if ($identicalIterationCount >= self::MAX_ITERATIONS_WITHOUT_PROGRESS) {
+                foreach ($nodesScheduledForRendering as $enumeratedNode) {
+                    $this->redisRenderingErrorManager->registerRenderingError(
+                        $contentReleaseIdentifier,
+                        ['node' => $enumeratedNode->debugString()],
+                        new \Exception(
+                            sprintf(
+                                'This node was scheduled for rendering %d times in a row without ever becoming complete in the content cache. Check the render worker logs for this node - most likely no "doc--..." mapping entry is written for it.',
+                                self::MAX_ITERATIONS_WITHOUT_PROGRESS
+                            )
+                        )
+                    );
+                }
+                $this->redisContentReleaseService->setContentReleaseMetadata(
+                    $contentReleaseIdentifier,
+                    $releaseMetadata->withStatus(NodeRenderingCompletionStatus::failed()),
+                    RedisInstanceIdentifier::primary()
+                );
+                $contentReleaseLogger->error(
+                    sprintf(
+                        'The same %d nodes were scheduled for rendering %d iterations in a row without any progress. EXITING now.',
+                        count($nodesScheduledForRendering),
+                        self::MAX_ITERATIONS_WITHOUT_PROGRESS
+                    )
+                );
+                yield ExitEvent::createWithStatusCode(self::EXIT_ERRORSTATUSCODE_RENDERING_ERRORS);
                 return;
             }
 

--- a/Classes/NodeRendering/NodeRenderer.php
+++ b/Classes/NodeRendering/NodeRenderer.php
@@ -6,26 +6,26 @@ namespace Flowpack\DecoupledContentStore\NodeRendering;
 
 use Flowpack\DecoupledContentStore\ContentReleaseManager;
 use Flowpack\DecoupledContentStore\Core\ConcurrentBuildLockService;
+use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\ContentReleaseIdentifier;
+use Flowpack\DecoupledContentStore\Core\Infrastructure\ContentReleaseLogger;
+use Flowpack\DecoupledContentStore\Exception\RenderingException;
+use Flowpack\DecoupledContentStore\NodeEnumeration\Domain\Dto\EnumeratedNode;
+use Flowpack\DecoupledContentStore\NodeRendering\Dto\RendererIdentifier;
 use Flowpack\DecoupledContentStore\NodeRendering\Extensibility\NodeRenderingExtensionManager;
+use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingErrorManager;
+use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingQueue;
 use Flowpack\DecoupledContentStore\NodeRendering\ProcessEvents\DocumentRenderedEvent;
 use Flowpack\DecoupledContentStore\NodeRendering\ProcessEvents\ExitEvent;
 use Flowpack\DecoupledContentStore\NodeRendering\ProcessEvents\QueueEmptyEvent;
-use Flowpack\DecoupledContentStore\PrepareContentRelease\Infrastructure\RedisContentReleaseService;
-use Neos\ContentRepository\Domain\Factory\NodeFactory;
-use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
-use Neos\Flow\Annotations as Flow;
-use Flowpack\DecoupledContentStore\Exception\RenderingException;
-use Flowpack\DecoupledContentStore\Core\Domain\ValueObject\ContentReleaseIdentifier;
-use Flowpack\DecoupledContentStore\Core\Infrastructure\ContentReleaseLogger;
-use Flowpack\DecoupledContentStore\NodeEnumeration\Domain\Dto\EnumeratedNode;
-use Flowpack\DecoupledContentStore\NodeRendering\Dto\RendererIdentifier;
-use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingErrorManager;
-use Flowpack\DecoupledContentStore\NodeRendering\Infrastructure\RedisRenderingQueue;
 use Flowpack\DecoupledContentStore\NodeRendering\Render\DocumentRenderer;
+use Flowpack\DecoupledContentStore\PrepareContentRelease\Infrastructure\RedisContentReleaseService;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Fusion\Core\Cache\ContentCache;
 use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Fusion\Helper\CachingHelper;
 
 /**
  * Not called directly, but through Scripts/renderWorker.sh.
@@ -60,6 +60,24 @@ class NodeRenderer
      * @var DocumentRenderer
      */
     protected $documentRenderer;
+
+    /**
+     * @Flow\Inject
+     * @var ContentCache
+     */
+    protected $contentCache;
+
+    /**
+     * @Flow\Inject
+     * @var CachingHelper
+     */
+    protected $cachingHelper;
+
+    /**
+     * @Flow\InjectConfiguration("nodeRendering.flushDocumentCacheOnRetry")
+     * @var bool
+     */
+    protected $flushDocumentCacheOnRetry;
 
     /**
      * @Flow\Inject
@@ -140,8 +158,18 @@ class NodeRenderer
                 continue;
             }
 
+            $renderingAttempt = $this->redisRenderingQueue->registerRenderingAttempt(
+                $contentReleaseIdentifier,
+                $enumeratedNode
+            );
+
             try {
-                $this->renderDocumentNodeVariant($enumeratedNode, $contentReleaseIdentifier, $contentReleaseLogger);
+                $this->renderDocumentNodeVariant(
+                    $enumeratedNode,
+                    $contentReleaseIdentifier,
+                    $contentReleaseLogger,
+                    $renderingAttempt
+                );
                 // BUGFIX: Because rendering a document node can update Thumbnails and their connected Persistent Resource
                 // objects (= Doctrine Entities), we need to *persist* these changes. Otherwise, we will have broken
                 // images, which will re-appear once you open the page in the backend (because image URL generation
@@ -188,8 +216,14 @@ class NodeRenderer
      * @param string $contextPath
      * @param array $arguments Request arguments when rendering the node
      * @param integer $releaseIdentifier
+     * @param int $renderingAttempt Number of the current attempt for this node within this content release (1 = first attempt)
      */
-    protected function renderDocumentNodeVariant(EnumeratedNode $enumeratedNode, ContentReleaseIdentifier $contentReleaseIdentifier, ContentReleaseLogger $contentReleaseLogger)
+    protected function renderDocumentNodeVariant(
+        EnumeratedNode $enumeratedNode,
+        ContentReleaseIdentifier $contentReleaseIdentifier,
+        ContentReleaseLogger $contentReleaseLogger,
+        int $renderingAttempt = 1
+    )
     {
         $nodeWasFound = false;
         try {
@@ -200,6 +234,10 @@ class NodeRenderer
                 $nodeWasFound = false;
             } else {
                 $nodeWasFound = true;
+
+                if ($renderingAttempt > 1) {
+                    $this->flushContentCacheForNode($node, $enumeratedNode, $renderingAttempt, $contentReleaseLogger);
+                }
 
                 $contentReleaseLogger->debug('Rendering document node variant', [
                     'node' => $node->getContextPath(),
@@ -246,6 +284,44 @@ class NodeRenderer
             $this->redisRenderingErrorManager->registerRenderingError($contentReleaseIdentifier, ['node' => $enumeratedNode->debugString()], new \Exception('We could not load a node which was part of the enumeration. At this point, the content release will definitely fail with no further possibility of recovery. Thus, we are exiting the rendering with an error'));
             $this->contentReleaseManager->startIncrementalContentRelease();
         }
+    }
+
+    /**
+     * A node is handed out for rendering more than once if the previous rendering did not produce a complete content
+     * cache entry for it - see {@see NodeRenderOrchestrator}.
+     *
+     * Simply rendering it again does not necessarily help: if the document's cache entries are still valid, the
+     * rendering is served straight from the content cache. In that case Fusion never processes a document-level cache
+     * segment, so {@see CacheUrlMappingAspect} does not write the "doc--..." mapping entry which the orchestrator is
+     * waiting for - and the node is scheduled again, and again, until the retry limit aborts the whole release.
+     *
+     * Flushing the node's cache entries before the retry turns the re-rendering into a real rendering again.
+     */
+    private function flushContentCacheForNode(
+        NodeInterface $node,
+        EnumeratedNode $enumeratedNode,
+        int $renderingAttempt,
+        ContentReleaseLogger $contentReleaseLogger
+    ): void {
+        if (!$this->flushDocumentCacheOnRetry) {
+            return;
+        }
+
+        $flushedEntriesCount = 0;
+        foreach ($this->cachingHelper->nodeTag($node) as $tag) {
+            $flushedEntriesCount += $this->contentCache->flushByTag($tag);
+        }
+
+        $contentReleaseLogger->warn(
+            sprintf(
+                'Rendering attempt %d for this node; flushed %d content cache entries before re-rendering it.',
+                $renderingAttempt,
+                $flushedEntriesCount
+            ),
+            [
+                'node' => $enumeratedNode->debugString(),
+            ]
+        );
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -42,6 +42,16 @@ Flowpack:
       # If "FALSE", the blacklisting is disabled.
       urlExcludelistRegex: false
 
+      # If a node has to be rendered more than once within the same content release, its content cache entries are
+      # flushed before the retry.
+      #
+      # Without this, a retry can be served completely from the content cache - and then CacheUrlMappingAspect never
+      # writes the "doc--..." mapping entry the NodeRenderOrchestrator is waiting for. The result is a content release
+      # which re-schedules the very same nodes until the retry limit is reached, without any rendering error.
+      #
+      # Set to `false` to get the old behaviour back.
+      flushDocumentCacheOnRetry: true
+
       # Set to `true` to render relative resource URIs
       useRelativeResourceUris: false
 
@@ -130,6 +140,11 @@ Flowpack:
         isRequired: false
       renderingJobQueue:
         redisKeyPostfix: 'renderingJobQueue'
+        transfer: false
+        transferMode: 'dump'
+        isRequired: false
+      renderAttempts:
+        redisKeyPostfix: 'renderAttempts'
         transfer: false
         transferMode: 'dump'
         isRequired: false

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ The following flow chart shows the rendering pipeline for creating a content rel
   successfully work, because an editor has changed pages at the same time; leading to content cache flushes and
   "holes" in the output.
 
+  From the second attempt on, the renderer **flushes the document's content cache entries** (by node tag) before
+  re-rendering it. Without this, a retry can be answered completely from the content cache - then no document-level
+  cache segment is processed, `CacheUrlMappingAspect` writes no `doc--...` mapping entry, and the orchestrator
+  schedules the very same node again in the next iteration. Can be turned off via the setting
+  `nodeRendering.flushDocumentCacheOnRetry`. If the identical set of nodes is scheduled three iterations in a row,
+  the orchestrator gives up early and registers a rendering error per node instead of running into the
+  10-attempt limit.
+
 - During **validation**, checks can happen to see whether the content release is fully complete; to check whether
   it really can go online.
 
@@ -525,6 +533,26 @@ CacheUrlMappingAspect - * NOTE: This aspect is NOT active during interactive pag
 
 If you need to debug single steps of the pipeline just run the corresponding commands from CLI, 
 e.g. `./flow nodeEnumeration:enumerateAllNodes {{ .contentReleaseId }}`.
+
+#### The orchestrator schedules the same nodes over and over again
+
+Symptom: `Scheduling rendering for Node, as it was not found or its content is incomplete: No Redis Key "doc--..."
+found.` for the same nodes in every iteration, and the release finally exits with code 3
+(`FAILED to build a complete content release after 10 rendering attempts`).
+
+`doc--<nodeId>-<dimensions>-<arguments>` is not content - it is the URL → root cache identifier mapping, written by
+`CacheUrlMappingAspect` *after* the document's content cache entries were stored. So anything interrupting a
+rendering between those two steps leaves content cache entries behind without a mapping entry, and a node in that
+state used to be unrecoverable: the re-render was served from the content cache, so the mapping entry was never
+written again.
+
+That case is self-healing now (see *Approach to Rendering* above), and both the aspect (`No "doc--..." mapping entry
+was written for this rendering`) and the orchestrator (rendering error per node, visible in the backend module) say
+so out loud. If you hit it on an older version, flush the affected documents from the Neos content cache
+(`./flow flow:cache:flushOne Neos_Fusion_Content` flushes all of it) and start a new content release.
+
+The orchestrator's exit codes: `1` release already completed, `2` empty enumeration, `3` retry limit reached,
+`4` rendering errors.
 
 ### Testing the Rendering
 


### PR DESCRIPTION
## Problem

A content release repeatedly failed on the same ~24 document nodes, with:

- exit code 3 (`FAILED to build a complete content release after 10 rendering attempts`)
- `contentStore:<release>:renderingErrors` **empty**
- nothing in the Backend UI, and nothing in any log above `DEBUG`

The only hint was one DEBUG line per iteration:

```
DEBUG: Scheduling rendering for Node, as it was not found or its content is incomplete:
No Redis Key "doc--19cc2e7d-…-__language_country____de_DE___-__" found.
```

## Root cause

The `doc--<nodeId>-<dimensions>-<arguments>` entry is not content - it is the
URL → rootIdentifier mapping which `CacheUrlMappingAspect::storeRootCacheIdentifier()`
writes `After ContentCache->processCacheSegments()`. It is the only writer, and it is
written *after* the document's content cache entries - anything that interrupts a
rendering between those two steps (worker restart, deployment, an exception in a
document metadata generator, ...) leaves content cache entries without a mapping entry.

Once a document is in that state, the release can never recover:

1. `NodeRenderOrchestrator` finds no mapping entry → schedules the node.
2. The render worker renders it, but Fusion serves the document from the content
   cache, so no document-level cache segment is processed. The aspect returns at its
   `cacheIdentifierValues['node']` guard - **silently**; every other early return in
   that method either logs (`Skipping URL`) or throws.
3. Nothing changed → the next iteration schedules the same node → 10 attempts → the
   whole release is aborted, without a single rendering error.

`DocumentRenderer::disableCache()` exists for exactly this kind of situation, but is
never called anywhere in the package - there was no way out of the loop.

In the incident that led to this PR, ~24 document nodes were in that state, stable
across every release for days. Cache eviction was ruled out on that installation
(`maxmemory_policy: volatile-lru` with no key in the cache carrying a TTL,
`evicted_keys: 0`), so the entries were removed or never written rather than dropped;
the exact origin was not determined. The point of this PR is that it does not matter -
a content release must be able to recover from it, and right now it cannot.

## Reproduction

With a single-node content release (enumeration containing one document):

1. Render it once so the content cache is warm → mapping entry exists, release succeeds.
2. `DEL <prefix>Neos_Fusion_Content:entry:doc--<nodeId>-…` (only the mapping entry).
3. Start another release for the same node.

→ 10 iterations of `No Redis Key "doc--…" found.`, `Mapping URL` never logged,
`renderingErrors` empty, exit code 3.

## Changes

**1. Retries actually re-render** (`NodeRenderer`, `RedisRenderingQueue`, `Settings.yaml`)

- `RedisRenderingQueue::registerRenderingAttempt()` counts attempts per enumerated node
  in a new `contentStore:<release>:renderAttempts` redis hash (registered under
  `redisKeyPostfixesForEachRelease`, `transfer: false`, cleared together with the queue).
- From the second attempt on, `NodeRenderer::flushContentCacheForNode()` flushes the
  node's content cache entries (`Neos.Caching.nodeTag()`) before rendering, so the
  re-rendering is a real rendering and the mapping entry is written again.
- New setting `nodeRendering.flushDocumentCacheOnRetry` (default `true`) to opt out.

This also makes the scenario described in the `NodeRenderer` class docblock
("If the above happens often, we can add additional code to take care of this")
self-healing, and it makes eviction of `doc--` keys harmless.

**2. No more silent skips** (`CacheUrlMappingAspect`)

Tracks per document rendering whether a mapping entry was written, and logs a warning
in `afterDocumentRendering()` if not - naming both causes (rendering served from the
content cache, or URL excluded via `nodeRendering.urlExcludelistRegex` while the node
is still part of the enumeration). One warning per document rendering, not per cache
segment.

**3. Fail loudly instead of grinding to the retry limit** (`NodeRenderOrchestrator`)

If an iteration schedules the identical set of nodes as the previous ones, three
iterations in a row, a rendering error is registered per node - which surfaces them in
the Backend UI - and the release exits with `EXIT_ERRORSTATUSCODE_RENDERING_ERRORS`
instead of iterating up to 10 times and failing with an empty error set. The second
iteration is left untouched on purpose, so change 1 gets its retry.

## Verification

Single-node content release against a production dataset:

| scenario | before | after |
| --- | --- | --- |
| cold content cache | success | success (unchanged) |
| mapping entry deleted, rest of the cache warm | failed after 10 iterations, `renderingErrors` empty | succeeds on iteration 2 |
| mapping entry can never be written (URL hits the excludelist while node is enumerated) | failed after 10 iterations, silently | fails after 3 iterations, 1 rendering error naming the node |

Log of the recovering run:

```
it.1  Rendering document for URI …/bmw-s-1000-rr          ← served from content cache
      WARNING: No "doc--..." mapping entry was written for this rendering…
it.2  WARNING: Rendering attempt 2 for this node; flushed 5 content cache entries before re-rendering it.
      DEBUG: Mapping URL …/bmw-s-1000-rr to b1310df5bee9a9bf6c6a65bf89f27860 with tags Node_%…%_19cc2e7d…
it.3  Everything rendered completely in 5 seconds. Finishing RenderOrchestrator
```

## Compatibility notes

- New redis key postfix `renderAttempts` (`transfer: false`, `isRequired: false`), so
  nothing changes for content store transfers.
- A node that is re-rendered within a release now loses its content cache entries first.
  That costs one real rendering for a node which was, by definition, not usable for the
  content release anyway.
- Releases that make no progress now abort after 3 identical iterations instead of 10;
  the 10-attempt limit still applies to everything else.